### PR TITLE
Improve API tense parsing

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -4,6 +4,7 @@ module Main
 
 import           Data.Either
 import           NLP.Morphology.PT.Verb
+import           Text.Read                   (readEither)
 import           Test.Hspec
 
 main :: IO ()
@@ -47,12 +48,15 @@ main = do
         let t1 = mkTense "falar" IPRS
         fmap tenseTable t1 `shouldSatisfy` isRight
         fmap tenseForms t1 `shouldSatisfy` isRight
-    describe "mkParadigm Tests" $ do
-      it "Creates a paradigm for a valid citation" $ do
-        let p1 = mkParadigm "falar"
-        fmap citation p1 `shouldSatisfy` isRight
-        fmap tenseTables p1 `shouldSatisfy` isRight
-      it "Fails to create a paradigm for an invalid citation" $ do
-        let p2 = mkParadigm "f"
-        fmap citation p2 `shouldSatisfy` isLeft
-        fmap tenseTables p2 `shouldSatisfy` isLeft
+  describe "mkParadigm Tests" $ do
+    it "Creates a paradigm for a valid citation" $ do
+      let p1 = mkParadigm "falar"
+      fmap citation p1 `shouldSatisfy` isRight
+      fmap tenseTables p1 `shouldSatisfy` isRight
+    it "Fails to create a paradigm for an invalid citation" $ do
+      let p2 = mkParadigm "f"
+      fmap citation p2 `shouldSatisfy` isLeft
+      fmap tenseTables p2 `shouldSatisfy` isLeft
+  describe "Input Parsing Tests" $ do
+    it "Invalid mood string returns Left" $
+      (readEither "INVALID" :: Either String MoodTense) `shouldSatisfy` isLeft


### PR DESCRIPTION
## Summary
- parse tense parameters with `readEither`
- update `createTenseHandler` error handling
- test invalid input parsing

## Testing
- `stack test --no-run-tests` *(fails: `stack` not found)*
- `cabal test --test-show-details=streaming` *(fails: `cabal` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fce1c0dc083249cb71531c9e2fa4f