### PR TITLE
Fix SPIF abbreviation

### DIFF
--- a/app/ApiDocs.md
+++ b/app/ApiDocs.md
@@ -113,7 +113,7 @@ Esse endpoint permite obter flexões verbais detalhadas para usos mais específi
 - `"IFUT"`: Futuro do Indicativo
 - `"COND"`: Condicional Presente
 - `"SPRS"`: Presente do Subjuntivo
-- `"SPIF"`: Pretérito Imperfeito do Subjuntivo
+- `"SIPF"`: Pretérito Imperfeito do Subjuntivo
 - `"SFUT"`: Futuro do Subjuntivo
 - `"IMPA"`: Imperativo Afirmativo
 - `"IMPN"`: Imperativo Negativo

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -84,7 +84,7 @@ GET /api/v1/paradigm/:citation
     - "IFUT": Futuro do Indicativo
     - "COND": Condicional Presente
     - "SPRS": Presente do Subjuntivo
-    - "SPIF": Pretérito Imperfeito do Subjuntivo
+    - "SIPF": Pretérito Imperfeito do Subjuntivo
     - "SFUT": Futuro do Subjuntivo
     - "IMPA": Imperativo Afirmativo
     - "IMPN": Imperativo Negativo


### PR DESCRIPTION
## Summary
- correct the conjugation abbreviation from SPIF to SIPF in docs and Main.hs

## Testing
- `stack test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fce170578832490e5c40824fb3d5f