### PR TITLE
docs: update API prefix to morphology/v1

### DIFF
--- a/app/ApiDocs.md
+++ b/app/ApiDocs.md
@@ -12,7 +12,7 @@
 
 ---
 
-### GET /api/v1/health
+### GET /morphology/v1/health
 
 **Descrição:**
 Retorna um JSON com o status da API, usado para verificar se a API está operacional. Ideal para rotinas de monitoramento.
@@ -40,7 +40,7 @@ Retorna um JSON com o status da API, usado para verificar se a API está operaci
 
 ---
 
-### GET /api/v1/paradigm/:citation
+### GET /morphology/v1/paradigm/:citation
 
 **Descrição:**
 Retorna um JSON contendo o paradigma verbal para a forma de citação do verbo especificado.  
@@ -61,7 +61,7 @@ Esse endpoint é útil em aplicativos que manipulam flexões verbais, como conju
 **Exemplo de Requisição:**
 
 ```http
-GET /api/v1/paradigm/correr
+GET /morphology/v1/paradigm/correr
 ```
 
 **Exemplo de Resposta Bem-sucedida:**
@@ -86,7 +86,7 @@ GET /api/v1/paradigm/correr
 
 ---
 
-### GET /api/v1/tense_paradigm/:citation/:tense
+### GET /morphology/v1/tense_paradigm/:citation/:tense
 
 **Descrição:**
 Retorna um JSON com o paradigma verbal para a forma de citação informada, filtrado por um tempo verbal específico.  
@@ -125,7 +125,7 @@ Esse endpoint permite obter flexões verbais detalhadas para usos mais específi
 **Exemplo de Requisição:**
 
 ```http
-GET /api/v1/tense_paradigm/correr/IPRS
+GET /morphology/v1/tense_paradigm/correr/IPRS
 ```
 
 **Exemplo de Resposta Bem-sucedida:**

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,6 +1,6 @@
 {-|
 
-GET /api/v1/health
+GET /morphology/v1/health
 
   Retorna um JSON com o status da API.
 
@@ -24,7 +24,7 @@ GET /api/v1/health
     "content": {}
   }
 
-GET /api/v1/paradigm/:citation
+GET /morphology/v1/paradigm/:citation
 
   Retorna um JSON com o paradigma do verbo para a forma de citação informada.
 
@@ -46,7 +46,7 @@ GET /api/v1/paradigm/:citation
     - :citation: Forma de citação do verbo (por exemplo, "correr", "amar").
 
   Exemplo prático:
-    - Requisição: GET /api/v1/paradigm/correr
+    - Requisição: GET /morphology/v1/paradigm/correr
 
   Exemplo de resposta bem-sucedida:
   {
@@ -62,7 +62,7 @@ GET /api/v1/paradigm/:citation
     "content": {}
   }
 
-### GET /api/v1/tense_paradigm/:citation/:tense
+### GET /morphology/v1/tense_paradigm/:citation/:tense
   Retorna um JSON com o paradigma do verbo para a forma de citação informada no tempo verbal informado.
 
   Este endpoint é usado para recuperar informações sobre o paradigma verbal de um verbo específico em um tempo verbal específico.
@@ -94,7 +94,7 @@ GET /api/v1/paradigm/:citation
     - "PPP": Particípio Passado Passivo
 
   Exemplo prático:
-    - Requisição: GET /api/v1/tense_paradigm/correr/IPRS
+    - Requisição: GET /morphology/v1/tense_paradigm/correr/IPRS
 
   Exemplo de resposta bem-sucedida:
   {
@@ -172,9 +172,9 @@ loggerLine url citation tense = do
         pack $ formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%QZ" currentTime
   let logLine =
         case url of
-          "GET /api/v1/health" -> isoTime <> " - " <> url <> "/"
-          "GET /api/v1/paradigm/" -> isoTime <> " - " <> url <> "/" <> citation
-          "GET /api/v1/tense_paradigm/" ->
+          "GET /morphology/v1/health" -> isoTime <> " - " <> url <> "/"
+          "GET /morphology/v1/paradigm/" -> isoTime <> " - " <> url <> "/" <> citation
+          "GET /morphology/v1/tense_paradigm/" ->
             isoTime <> " - " <> url <> "/" <> citation <> "/" <> tense
           _ -> isoTime <> " - " <> url
   return logLine
@@ -189,17 +189,17 @@ logRequest logger url citation tense = do
 -- Application Main
 defineRoutes :: FL.LoggerSet -> ScottyM ()
 defineRoutes logger = do
-  get "/api/v1/health" $ do
-    logRequest logger "GET /api/v1/health" "" ""
+  get "/morphology/v1/health" $ do
+    logRequest logger "GET /morphology/v1/health" "" ""
     json (ApiResponse "ok" "API is running" Nothing :: ApiResponse Text)
-  get "/api/v1/paradigm/:citation" $ createParadigmHandler logger
-  get "/api/v1/tense_paradigm/:citation/:tense"
+  get "/morphology/v1/paradigm/:citation" $ createParadigmHandler logger
+  get "/morphology/v1/tense_paradigm/:citation/:tense"
     $ createTenseHandler logger
 
 createParadigmHandler :: FL.LoggerSet -> ActionM ()
 createParadigmHandler logger = do
   citation <- pathParam "citation"
-  logRequest logger "GET /api/v1/paradigm/" citation ""
+  logRequest logger "GET /morphology/v1/paradigm/" citation ""
   let paradigm = mkParadigm (unpack citation)
   case paradigm of
     Left e -> json (ApiResponse "error" (pack e) Nothing :: ApiResponse Text)
@@ -211,7 +211,7 @@ createTenseHandler :: FL.LoggerSet -> ActionM ()
 createTenseHandler logger = do
   citation <- pathParam "citation" :: ActionM Text
   tense <- pathParam "tense" :: ActionM Text
-  logRequest logger "GET /api/v1/tense_paradigm/" citation tense
+  logRequest logger "GET /morphology/v1/tense_paradigm/" citation tense
   let paradigm = mkTense (unpack citation) (read $ unpack tense)
   case paradigm of
     Left e -> json (ApiResponse "error" (pack e) Nothing :: ApiResponse Text)


### PR DESCRIPTION
## Summary
- update API documentation to new `/morphology/v1` routes
- switch application routes and logger messages to use `/morphology/v1`

## Testing
- `stack test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd9858c3883248e888b88ea33fc83